### PR TITLE
Added recipes from meta-dts-distro to meta-coreboot as part of migratiom

### DIFF
--- a/recipes-bsp/coreboot-utils/cbfstool_git.bb
+++ b/recipes-bsp/coreboot-utils/cbfstool_git.bb
@@ -1,0 +1,27 @@
+require coreboot-utils.inc
+
+SUMMARY = "Tool for manipulating CBFS file"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+EXTRA_OEMAKE = " \
+    DESTDIR=\"${D}\" \
+    PREFIX=\"${prefix}\" \
+"
+
+INSANE_SKIP:${PN} = "textrel"
+
+do_configure:prepend () {
+    cd ${S}
+    git submodule update --init 3rdparty/vboot
+    cd -
+}
+
+do_compile () {
+    oe_runmake -C util/cbfstool cbfstool
+}
+
+do_install () {
+    install -d ${D}/${sbindir}
+    install ${S}/util/${PN}/${PN} ${D}/${sbindir}
+}

--- a/recipes-bsp/coreboot-utils/cbmem_git.bb
+++ b/recipes-bsp/coreboot-utils/cbmem_git.bb
@@ -1,0 +1,18 @@
+require coreboot-utils.inc
+
+SUMMARY = "CBMEM parser to read e.g. timestamps and console log"
+
+DEPENDS += "pciutils zlib"
+
+EXTRA_OEMAKE = ' \
+               DESTDIR="${D}" \
+               PREFIX="${prefix}" \
+               '
+
+do_compile () {
+  oe_runmake -C util/cbmem
+}
+
+do_install () {
+  oe_runmake -C util/cbmem install
+}

--- a/recipes-bsp/coreboot-utils/coreboot-utils.inc
+++ b/recipes-bsp/coreboot-utils/coreboot-utils.inc
@@ -1,0 +1,14 @@
+DESCRIPTION = "coreboot tools"
+HOMEPAGE = "https://doc.coreboot.org/util.html"
+SECTION = "coreboot"
+
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = " \
+    git://github.com/Dasharo/coreboot.git;protocol=https;branch=dasharo-4.21\
+    "
+
+SRCREV = "d08d5eaa98b1204b5e665d3ae4f63fb6f84a0d77"
+
+S = "${WORKDIR}/git"

--- a/recipes-bsp/coreboot-utils/ectool_git.bb
+++ b/recipes-bsp/coreboot-utils/ectool_git.bb
@@ -1,0 +1,16 @@
+require coreboot-utils.inc
+
+SUMMARY = "Dumps the RAM of a laptop's Embedded/Environmental Controller (EC)."
+
+EXTRA_OEMAKE = ' \
+               DESTDIR="${D}" \
+               PREFIX="${prefix}" \
+               '
+
+do_compile () {
+  oe_runmake -C util/ectool
+}
+
+do_install () {
+  oe_runmake -C util/ectool install
+}

--- a/recipes-bsp/coreboot-utils/files/0001-Makefile-disable-deprecated-warnigs-as-errors.patch
+++ b/recipes-bsp/coreboot-utils/files/0001-Makefile-disable-deprecated-warnigs-as-errors.patch
@@ -1,0 +1,25 @@
+From 2c095fae49351a6be86934658e20de0e9f985061 Mon Sep 17 00:00:00 2001
+From: wkawka <wiktor.kawka@3mdeb.com>
+Date: Fri, 16 Sep 2022 11:09:29 +0200
+Subject: [PATCH] Makefile: disable deprecated warnings as errors
+
+Signed-off-by: wkawka <wiktor.kawka@3mdeb.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 7f38bd6b..e3615a11 100644
+--- a/Makefile
++++ b/Makefile
+@@ -124,7 +124,7 @@ endif
+ # Provide default CC and CFLAGS for firmware builds; if you have any -D flags,
+ # please add them after this point (e.g., -DVBOOT_DEBUG).
+ DEBUG_FLAGS := $(if ${DEBUG},-g -Og,-g -Os)
+-WERROR := -Werror
++WERROR := -Werror -Wno-deprecated-declarations
+ FIRMWARE_FLAGS := -nostdinc -ffreestanding -fno-builtin -fno-stack-protector
+ COMMON_FLAGS := -pipe ${WERROR} -Wall -Wstrict-prototypes -Wtype-limits \
+ 	-Wundef -Wmissing-prototypes -Wno-trigraphs -Wredundant-decls -Wshadow \
+-- 
+2.25.1

--- a/recipes-bsp/coreboot-utils/futil_git.bb
+++ b/recipes-bsp/coreboot-utils/futil_git.bb
@@ -1,0 +1,51 @@
+SUMMARY = "\
+    Firmware utility tool, used to create, sign, and validate Chrome \
+    OS images."
+
+HOMEPAGE = "https://github.com/Dasharo/vboot"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=562c740877935f40b262db8af30bca36"
+
+DEPENDS += " \
+    openssl \
+    flashrom \
+"
+
+SRC_URI = " \
+    git://github.com/Dasharo/vboot.git;protocol=https;branch=dasharo \
+    file://0001-Makefile-disable-deprecated-warnigs-as-errors.patch \
+"
+SRCREV = "dc68f9f1b56d92f76026dca490e79493599ff4cf"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+RDEPENDS:${PN} += " \
+    bash \
+"
+
+EXTRA_OEMAKE = " \
+    DESTDIR=\"${D}\" \
+    PREFIX=\"${prefix}\"\
+"
+
+INSANE_SKIP:${PN} = "textrel"
+
+do_compile() {
+  oe_runmake futil
+}
+
+do_install() {
+    # we only install futility binary and couple of scripts that are used by
+    # dasharo-deploy script
+    install -d ${D}/${sbindir}
+    install -d ${D}/${bindir}
+    install -m 755 ${S}/build/futility/futility ${D}/${bindir}
+    install ${S}/scripts/image_signing/resign_firmwarefd.sh ${D}/${sbindir}
+    install ${S}/scripts/image_signing/common_minimal.sh ${D}/${sbindir}
+    install ${S}/scripts/image_signing/sign_firmware.sh ${D}/${sbindir}
+}

--- a/recipes-bsp/coreboot-utils/ifdtool_git.bb
+++ b/recipes-bsp/coreboot-utils/ifdtool_git.bb
@@ -1,0 +1,18 @@
+require coreboot-utils.inc
+
+SUMMARY = "Extract and dump Intel Firmware Descriptor information"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+EXTRA_OEMAKE = ' \
+               DESTDIR="${D}" \
+               PREFIX="${prefix}" \
+               '
+
+do_compile () {
+  oe_runmake -C util/ifdtool
+}
+
+do_install () {
+  oe_runmake -C util/ifdtool install
+}

--- a/recipes-bsp/coreboot-utils/intelmetool_git.bb
+++ b/recipes-bsp/coreboot-utils/intelmetool_git.bb
@@ -1,0 +1,20 @@
+require coreboot-utils.inc
+
+SUMMARY = "Dump interesting things about Management Engine even if hidden"
+
+DEPENDS += "pciutils zlib"
+
+EXTRA_OEMAKE = ' \
+               DESTDIR="${D}" \
+               PREFIX="${prefix}" \
+               '
+
+TARGET_CFLAGS += "-I../../src/commonlib/bsd/include"
+
+do_compile () {
+  oe_runmake -C util/intelmetool
+}
+
+do_install () {
+  oe_runmake -C util/intelmetool install
+}

--- a/recipes-bsp/coreboot-utils/intelp2m_git.bb
+++ b/recipes-bsp/coreboot-utils/intelp2m_git.bb
@@ -1,0 +1,35 @@
+require coreboot-utils.inc
+
+SUMMARY = "\
+    Converts the configuration DW0/1 registers value from an inteltool \
+    dump to coreboot macros.\
+"
+
+LIC_FILES_CHKSUM = "file://../../COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+GO_IMPORT = "github.com/dasharo/coreboot/"
+
+# we need to override SRC_URI from coreboot-utils.inc so it's unpacked in the
+# directory as expected by the go bbclass
+SRC_URI = " \
+    git://github.com/dasharo/coreboot.git;protocol=https;branch=dasharo-4.21;destsuffix=${GO_IMPORT} \
+    "
+
+S = "${WORKDIR}/${GO_IMPORT}/util/intelp2m"
+
+inherit goarch
+inherit go
+
+do_compile() {
+    export GOARCH="${TARGET_GOARCH}"
+    export GOPATH="${WORKDIR}/git/"
+
+    cd ${S}
+
+    oe_runmake
+}
+
+do_install() {
+    install -d ${D}/${sbindir}
+    install ${S}/${PN} ${D}/${sbindir}
+}

--- a/recipes-bsp/coreboot-utils/inteltool_git.bb
+++ b/recipes-bsp/coreboot-utils/inteltool_git.bb
@@ -1,0 +1,21 @@
+require coreboot-utils.inc
+
+SUMMARY = "\
+    Provides information about the Intel CPU/chipset hardware \
+    configuration (register contents, MSRs, etc).\
+"
+
+DEPENDS += "pciutils zlib"
+
+EXTRA_OEMAKE = ' \
+               DESTDIR="${D}" \
+               PREFIX="${prefix}" \
+               '
+
+do_compile () {
+  oe_runmake -C util/inteltool
+}
+
+do_install () {
+  oe_runmake -C util/inteltool install
+}

--- a/recipes-bsp/coreboot-utils/msrtool_git.bb
+++ b/recipes-bsp/coreboot-utils/msrtool_git.bb
@@ -1,0 +1,7 @@
+require coreboot-utils.inc
+
+SUMMARY = "Dumps chipset-specific MSR registers."
+DEPENDS += "pciutils"
+S = "${WORKDIR}/git/util/msrtool"
+export PREFIX = "${prefix}"
+inherit autotools-brokensep

--- a/recipes-bsp/coreboot-utils/nvramtool_git.bb
+++ b/recipes-bsp/coreboot-utils/nvramtool_git.bb
@@ -1,0 +1,16 @@
+require coreboot-utils.inc
+
+SUMMARY = "Reads and writes coreboot parameters and displaying information from the coreboot table in CMOS/NVRAM. "
+
+EXTRA_OEMAKE = ' \
+               DESTDIR="${D}" \
+               PREFIX="${prefix}" \
+               '
+
+do_compile () {
+  oe_runmake -C util/nvramtool
+}
+
+do_install () {
+  oe_runmake -C util/nvramtool install
+}

--- a/recipes-bsp/coreboot-utils/superiotool_git.bb
+++ b/recipes-bsp/coreboot-utils/superiotool_git.bb
@@ -1,0 +1,18 @@
+require coreboot-utils.inc
+
+SUMMARY = "A user-space utility to detect Super I/O of a mainboard and provide detailed information about the register contents of the Super I/O. "
+
+DEPENDS += "pciutils zlib"
+
+EXTRA_OEMAKE = ' \
+               DESTDIR="${D}" \
+               PREFIX="${prefix}" \
+               '
+
+do_compile () {
+  oe_runmake -C util/superiotool
+}
+
+do_install () {
+  oe_runmake -C util/superiotool install
+}

--- a/recipes-bsp/packagegroups/packagegroup-coreboot-utils.bb
+++ b/recipes-bsp/packagegroups/packagegroup-coreboot-utils.bb
@@ -1,0 +1,24 @@
+SUMMARY = "coreboot-utils packagegroup"
+DESCRIPTION = "coreboot-utils packagegroup"
+
+LICENSE = "MIT"
+
+inherit packagegroup
+
+PACKAGES = " \
+    packagegroup-coreboot-utils \
+"
+
+RDEPENDS:${PN} = " \
+    cbfstool \
+    cbmem \
+    ectool \
+    futil \
+    ifdtool \
+    intelp2m \
+    inteltool \
+    intelmetool \
+    msrtool \
+    nvramtool \
+    superiotool \
+"


### PR DESCRIPTION
Signed-off-by: Alan Ostrowski <alan.ostrowski@3mdeb.com>

Recipes that have been moved to meta-coreboot:

coreboot-utils:

    cbfstool
    cmem
    ectool
    futil
    ifdtool
    intelmetool
    intelp2m
    inteltool
    msrtool
    nvramtool
    superiotool
    smmstoretool

packagegroups:

    packagegroup-coreboot-utils